### PR TITLE
Changed way Label equality check is performed

### DIFF
--- a/src/main/java/com/maxdemarzi/SuspectRunnable.java
+++ b/src/main/java/com/maxdemarzi/SuspectRunnable.java
@@ -30,7 +30,7 @@ public class SuspectRunnable implements Runnable {
             }
 
             for (LabelEntry labelEntry : td.assignedLabels()) {
-                if (labelEntry.label().equals(Labels.Suspect) && !suspects.contains(labelEntry.node())) {
+                if (labelEntry.label().name().equals(Labels.Suspect.name()) && !suspects.contains(labelEntry.node())) {
                     System.out.println("A new Suspect has been identified!");
                     suspects.add(labelEntry.node());
                 }


### PR DESCRIPTION
`lableEntry.label().equals(Labels.Suspect)` fails even for Suspect nodes on this line in `Label.equals(Object that)`

     `if ( that == null || that.getClass() != getClass() )`

The better fix may be to change the implementation of Label.equals() but as a short term fix, this change compares the labels' names directly.
